### PR TITLE
Fix handling of Windows paths with parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ file system objects without spaces.  To do this
 `Win32::GetShortPathName()` is used on to find alternative
 path names without spaces.
 
+NOTE that this breaks when Windows is told not to create
+short (`8+3`) filenames; see [http://www.perlmonks.org/?node\_id=333930](http://www.perlmonks.org/?node_id=333930)
+for a discussion of this behaviour.
+
 In addition, on just `Cygwin`:
 
 The input paths are first converted from POSIX to Windows paths
@@ -275,6 +279,16 @@ POSIX paths using `Cygwin::win_to_posix_path`.
 Elsewhere:
 
 Returns the same list passed into it
+
+## cmd\_escape\_path( @path\_list )
+
+Given a list of directory paths (or filenames), this will
+return an equivalent list of paths escaped for cmd.exe and command.com.
+
+## powershell\_escape\_path( @path\_list )
+
+Given a list of directory paths (or filenames), this will
+return an equivalent list of paths escaped for PowerShell.
 
 # CAVEATS
 

--- a/t/alias.t
+++ b/t/alias.t
@@ -39,8 +39,8 @@ foreach my $shell (qw( tcsh csh bsd-csh bash sh zsh cmd.exe command.com ksh 44bs
     plan skip_all => "not testing sh in case it doesn't support aliases" if $shell eq 'sh';
     plan skip_all => "alias may not work with non-interactive cmd.exe or command.com"
       if $shell eq 'cmd.exe' || $shell eq 'command.com';
-    plan skip_all => "skipping powershell on cygwin or msys"
-      if $shell eq 'powershell.exe' && $^O =~ /^(cygwin|msys)$/;
+    plan skip_all => "skipping powershell on msys"
+      if $shell eq 'powershell.exe' && $^O =~ /^(msys)$/;
     my $list = get_env($config, $shell, $shell_path, 'myecho1 one two three');
     is_deeply $list, [ qw( f00f one two three )], 'arguments match';
   };


### PR DESCRIPTION
Hi Graham,

This PR fixes handling of paths that include parentheses on both MSWin32 (e.g. Strawberry Perl) and Cygwin for issue #12 .

I've added two functions (`cmd_escape_path` and `powershell_escape_path`) that are needed within the test suite; while I could have called them internally I thought it better to expose them. You may have different ideas though :-)

I also removed the skip of PowerShell testing under Cygwin as it tests just fine on my system. You may want to revert that if using PowerShell in conjunction with Cygwin is not something you'd want to do.

Finally, I added checks in the test suite to use `type` rather than `cat` on Windows systems.

Hope this helps!

Cheers

Brad